### PR TITLE
Fix unit tests reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ http://flask-sqlalchemy.pocoo.org/2.3/quickstart/
 
 Flask Documentation
 http://flask.pocoo.org/docs/1.0/
+
+PyTest
+https://docs.pytest.org/en/latest/contents.html
+* Writing your first test
+https://docs.pytest.org/en/latest/getting-started.html#create-your-first-test
+* Mocking
+https://docs.pytest.org/en/latest/monkeypatch.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 asn1crypto==0.24.0
+atomicwrites==1.1.5
+attrs==18.1.0
 bcrypt==3.1.4
 cffi==1.11.5
 click==6.7
@@ -13,7 +15,12 @@ Jinja2==2.10
 jwt==0.5.4
 livereload==2.5.2
 MarkupSafe==1.0
+more-itertools==4.2.0
+mpi4py==3.0.0
+pluggy==0.6.0
+py==1.5.4
 pycparser==2.18
+pytest==3.6.3
 six==1.11.0
 SQLAlchemy==1.2.10
 SQLAlchemy-Utils==0.33.3

--- a/test/test_company.py
+++ b/test/test_company.py
@@ -1,0 +1,18 @@
+from eagleEvents.models import company, user
+from eagleEvents import db
+from flask_sqlalchemy import SQLAlchemy
+
+def mock_db(monkeypatch):
+    db = SQLAlchemy()
+    monkeypatch.setattr(db, 'Model', {})
+    return db
+
+def test_thing():
+  assert 1 == 1
+
+def test_when_getting_event_planners_then_it_returns_all_users(monkeypatch):
+    db = mock_db(monkeypatch)
+    c = company.Company()
+    mocklist = [user.User(company)]
+    monkeypatch.setattr(c, 'users', mocklist)
+    assert(len(c.get_event_planners()) == 1)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1,3 +1,0 @@
-
-def test_thing():
-   assert 1 == 1

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1,0 +1,3 @@
+
+def test_thing():
+   assert 1 == 1


### PR DESCRIPTION
Running `manage.py test` would break because `pytest` isn't included in `requirements.txt`:
https://github.com/simpleman19/eagleEvents/blob/506e2c4d59cc3057357cebbda0ae1be33506c884/manage.py#L39-L44

I added some example tests to help with the learning curve:
https://github.com/simpleman19/eagleEvents/blob/07d874960c77540f05e64868f90c5f19d5076ffe/test/test_company.py#L5-L18

@simpleman19 Should there be anything in `test/__init__.py`? Or should I delete this file since it's empty?

If anyone wants this immediately, go ahead and review it otherwise let's leave it up to Chance to review.